### PR TITLE
Add test and fix for valid_range check for check_actual_range

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -4619,15 +4619,13 @@ class CF1_7Check(CF1_6Check):
                 # NOTE this is a data check
                 # If every value is masked, a data check of actual_range isn't
                 # appropriate, so skip.
-                if not (hasattr(variable[:], "mask") and
-                        variable[:].mask.all()):
+                if not (hasattr(variable[:], "mask") and variable[:].mask.all()):
                     # if min/max values aren't close to actual_range bounds,
                     # fail.
                     out_of += 1
-                    if (not np.isclose(variable.actual_range[0], variable[:].min())
-                        or
-                        not np.isclose(variable.actual_range[1], variable[:].max())
-                        ):
+                    if not np.isclose(
+                        variable.actual_range[0], variable[:].min()
+                    ) or not np.isclose(variable.actual_range[1], variable[:].max()):
                         msgs.append(
                             "actual_range elements of '{}' inconsistent with its min/max values".format(
                                 name

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -4637,8 +4637,8 @@ class CF1_7Check(CF1_6Check):
                         score += 1
 
                 # check that the actual range is within the valid range
-                out_of += 1
                 if hasattr(variable, "valid_range"):  # check within valid_range
+                    out_of += 1
                     if (variable.actual_range[0] < variable.valid_range[0]) or (
                         variable.actual_range[1] > variable.valid_range[1]
                     ):
@@ -4647,8 +4647,8 @@ class CF1_7Check(CF1_6Check):
                                 name
                             )
                         )
-                else:
-                    score += 1
+                    else:
+                        score += 1
 
                 # check the elements of the actual range have the appropriate
                 # relationship to the valid_min and valid_max

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1527,11 +1527,6 @@ class TestCF1_7(BaseTestCase):
         )
         dataset.close()
 
-
-
-
-
-
         # check that scale_factor operates properly to min and max values
         # case If the data is packed and valid_range is defined
         dataset = MockTimeSeries()
@@ -1551,7 +1546,7 @@ class TestCF1_7(BaseTestCase):
         dataset.close()
 
         # check that scale_factor operates properly to min and max values
-        # case If _FillValues is used        
+        # case If _FillValues is used
         dataset = MockTimeSeries()
         dataset.createVariable("a", "d", ("time",), fill_value=9999.9)
         dataset.variables["a"][0] = 1

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1527,7 +1527,31 @@ class TestCF1_7(BaseTestCase):
         )
         dataset.close()
 
+
+
+
+
+
         # check that scale_factor operates properly to min and max values
+        # case If the data is packed and valid_range is defined
+        dataset = MockTimeSeries()
+        dataset.createVariable("a", "d", ("time",))
+        dataset.variables["a"][0] = 1
+        dataset.variables["a"][1] = 2
+        dataset.variables["a"].add_offset = 2.0
+        dataset.variables["a"].scale_factor = 10
+        # Check against set _FillValue to ensure it's not accidentally slipping
+        # by.
+        dataset.variables["a"].setncattr("actual_range", [12, 22])
+        dataset.variables["a"].setncattr("valid_range", [0, 100])
+        result = self.cf.check_actual_range(dataset)
+        score, out_of, messages = get_results(result)
+        assert score == out_of
+        assert len(messages) == 0
+        dataset.close()
+
+        # check that scale_factor operates properly to min and max values
+        # case If _FillValues is used        
         dataset = MockTimeSeries()
         dataset.createVariable("a", "d", ("time",), fill_value=9999.9)
         dataset.variables["a"][0] = 1

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1527,7 +1527,6 @@ class TestCF1_7(BaseTestCase):
         )
         dataset.close()
 
-        # check that scale_factor operates properly to min and max values
         # case If the data is packed and valid_range is defined
         dataset = MockTimeSeries()
         dataset.createVariable("a", "d", ("time",))
@@ -1535,8 +1534,6 @@ class TestCF1_7(BaseTestCase):
         dataset.variables["a"][1] = 2
         dataset.variables["a"].add_offset = 2.0
         dataset.variables["a"].scale_factor = 10
-        # Check against set _FillValue to ensure it's not accidentally slipping
-        # by.
         dataset.variables["a"].setncattr("actual_range", [12, 22])
         dataset.variables["a"].setncattr("valid_range", [0, 100])
         result = self.cf.check_actual_range(dataset)


### PR DESCRIPTION
Ben, your changes look good to me. I can't imagine what removing the mask was trying to accomplish, but removing it doesn't seem to cause regression according to the tests. 

[This check you added](https://github.com/ioos/compliance-checker/blob/73a4c5bf5f011bb5d73d8e285568ec7d30e67a84/compliance_checker/tests/test_cf.py#L1530-L1544) should ensure the fill_value case is fixed. However, I added another check for the other case @yosoyjay brought up, if the data is packed and valid_range is defined ([721](https://github.com/ioos/compliance-checker/issues/721)), and it failed. It was just a couple lines out of order in check_actual_range as you can see from the diff, causing an edge case where you could miss a point but get no messages for it. 

I really wanted to go ahead and parameterize these multiple checks in 1 test, but it seems everything is inheriting from a legacy unittest testCase? I'll get with you offline to see if we can pytestify some of this.